### PR TITLE
playbook.yml, templates: Handle absent rc.local

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -87,28 +87,43 @@
                 state=present
 
     - name: secure redis
-      lineinfile: dest=/etc/redis/redis.conf
-                regexp='^# requirepass \w*$'
-                line='requirepass {{ redis_password }}'
-                state=present
+      lineinfile: 
+        dest: /etc/redis/redis.conf
+        regexp: '^# requirepass \w*$'
+        line: 'requirepass {{ redis_password }}'
+        state: present
 
     - name: bind to redis.bind_addr
-      lineinfile: dest=/etc/redis/redis.conf
-                regexp='^bind {{ ipv4_addr }}$'
-                line='bind {{ redis_bind_addr }}'
-                state=present
+      lineinfile: 
+        dest: /etc/redis/redis.conf
+        regexp: '^bind {{ ipv4_addr }}$'
+        line: 'bind {{ redis_bind_addr }}'
+        state: present
 
     - name: configure logging
-      lineinfile: dest=/etc/redis/redis.conf
-                regexp='^logfile ""$'
-                line='logfile {{ redis_logfile }}'
-                state=present
+      lineinfile: 
+        dest: /etc/redis/redis.conf
+        regexp: '^logfile ""$'
+        line: 'logfile {{ redis_logfile }}'
+        state: present
+
+    - name: Check rc.local exists
+      stat:
+        path: /etc/rc.local
+      register: rc_local
+
+    - name: Create rc.local if not present
+      when: rc_local.islnk is not defined
+      template:
+        src: templates/rc.local
+        dest: /etc/rc.local
+        mode: '0755'
 
     - name: disable Transparent Huge Pages (THP) support
       lineinfile: dest=/etc/rc.local
-                insertbefore='^exit 0$'
-                line='echo never > /sys/kernel/mm/transparent_hugepage/enabled'
-                state=present
+            	  insertbefore='^exit 0$'
+          	  line='echo never > /sys/kernel/mm/transparent_hugepage/enabled'
+          	  state=present
       become: yes
 
     - name: fix TCP backlog

--- a/templates/rc.local
+++ b/templates/rc.local
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# By default this script does nothing.
+
+exit 0


### PR DESCRIPTION
I was running this against Vagrant on Ubuntu 18.04.3 LTS (bionic) and ran into an issue where the playbook bombed out trying to handle the THP task which requires adding config to rc.local.

The idea for the fix is to use a register to check if `/etc/rc.local` exist, and create it by copying a template file across.

### Improvements:
- Definitely needs testing first!
- Are the permissions used minimal enough? rwx for user, read/write for group and other maybe too much? Not familiar with rc and permissions.
- Could possibly also add the lines used to handle THP and the TCP issue
using the template?
- I could standardise the syntax so the playbook uses `:` vs `=`. It's currently a mishmash of both as I'm only familiar with using `:`.

Any feedback gratefully received!

